### PR TITLE
add skip params for findMany method

### DIFF
--- a/src/ModelOps/ModelOps.ts
+++ b/src/ModelOps/ModelOps.ts
@@ -210,6 +210,7 @@ interface NeogmaModelStaticsI<
             /** where params for the nodes of this Model */
             where?: WhereParamsI;
             limit?: number;
+            skip?: number;
             order?: Array<[Extract<keyof Properties, string>, 'ASC' | 'DESC']>;
         },
     ) => Promise<Instance[]>;
@@ -1324,6 +1325,10 @@ export const ModelFactory = <
 
             if (params?.limit) {
                 queryBuilder.limit(+params.limit);
+            }
+
+            if (params?.skip) {
+                queryBuilder.skip()
             }
 
             const res = await queryBuilder.run(queryRunner, params?.session);

--- a/src/ModelOps/ModelOps.ts
+++ b/src/ModelOps/ModelOps.ts
@@ -1328,7 +1328,7 @@ export const ModelFactory = <
             }
 
             if (params?.skip) {
-                queryBuilder.skip()
+                queryBuilder.skip(+params.skip);
             }
 
             const res = await queryBuilder.run(queryRunner, params?.session);

--- a/src/Queries/Where/Where.spec.ts
+++ b/src/Queries/Where/Where.spec.ts
@@ -15,14 +15,20 @@ describe('Where', () => {
                     c: {
                         [Op.in]: inValue,
                     },
+                    d: {
+                        [Op.contains]: 'test-string',
+                    },
                 },
             });
 
             expect(
                 where.getStatement('text').includes('identifier.c IN $c'),
             ).toBeTruthy();
+            expect(
+                where.getStatement('text').includes('identifier.d CONTAINS $d'),
+            ).toBeTruthy();
             expect(where.getBindParam().get().c).toEqual(inValue);
-            expect(Object.keys(where.getBindParam().get()).length).toEqual(2);
+            expect(Object.keys(where.getBindParam().get()).length).toEqual(3);
         });
     });
 

--- a/src/Queries/Where/Where.spec.ts
+++ b/src/Queries/Where/Where.spec.ts
@@ -27,6 +27,7 @@ describe('Where', () => {
             expect(
                 where.getStatement('text').includes('identifier.d CONTAINS $d'),
             ).toBeTruthy();
+            expect(where.getBindParam().get().d).toEqual('test-string');
             expect(where.getBindParam().get().c).toEqual(inValue);
             expect(Object.keys(where.getBindParam().get()).length).toEqual(3);
         });

--- a/src/Queries/Where/Where.ts
+++ b/src/Queries/Where/Where.ts
@@ -169,7 +169,7 @@ export class Where {
                     this.addBindParamDataEntry({
                         identifier: nodeIdentifier,
                         property,
-                        value: value[Op.in],
+                        value: value[Op.contains],
                         operator: 'contains',
                     });
                 }

--- a/src/Queries/Where/Where.ts
+++ b/src/Queries/Where/Where.ts
@@ -8,8 +8,10 @@ import { NeogmaConstraintError } from '../../Errors';
 
 /** symbols for Where operations */
 const OpIn: unique symbol = Symbol('in');
+const OpContains: unique symbol = Symbol('contains');
 export const Op = {
     in: OpIn,
+    contains: OpContains,
 } as const;
 
 /** the type to be used for "in" */
@@ -17,8 +19,16 @@ interface WhereInI {
     [Op.in]: Neo4jSingleTypes[];
 }
 
+interface WhereContainsI {
+    [Op.contains]: string;
+}
+
 const isWhereIn = (value: WhereValuesI): value is WhereInI => {
     return value?.[Op.in];
+};
+
+const isWhereContains = (value: WhereValuesI): value is WhereContainsI => {
+    return value?.[Op.contains];
 };
 
 const isNeo4jSupportedTypes = (
@@ -48,7 +58,7 @@ const isNeo4jSupportedTypes = (
 };
 
 /** the type for the accepted values for an attribute */
-export type WhereValuesI = Neo4jSupportedTypes | WhereInI;
+export type WhereValuesI = Neo4jSupportedTypes | WhereInI | WhereContainsI;
 
 /**
  * an object to be used for a query identifier
@@ -85,7 +95,7 @@ export class Where {
         identifier: string;
         property: string;
         bindParamName: string;
-        operator: 'equals' | 'in';
+        operator: 'equals' | 'in' | 'contains';
     }> = [];
 
     constructor(
@@ -155,6 +165,13 @@ export class Where {
                         value: value[Op.in],
                         operator: 'in',
                     });
+                } else if (isWhereContains(value)) {
+                    this.addBindParamDataEntry({
+                        identifier: nodeIdentifier,
+                        property,
+                        value: value[Op.in],
+                        operator: 'contains',
+                    });
                 }
             }
         }
@@ -222,6 +239,7 @@ export class Where {
             > = {
                 equals: '=',
                 in: 'IN',
+                contains: 'CONTAINS',
             };
 
             // else, return the appropriate text-mode operator


### PR DESCRIPTION
- Add skip param for findMany method to resolve pagination logic
```ts
  Apps.findMany({
    where: {
      platform: where.platform
    },
    limit: pageSize,
    skip: pageNo * pageSize
  });
```
- Support new operator `Op.contains` for where
```ts
const queryBuilder = new QueryBuilder()
    .match({
        identifier: 'a',
    })
    .where({
        a: {
            id: { [Op.contains]: '1' },
        },
    });
```