### PR TITLE
Fix: improve properties check for an empty object

### DIFF
--- a/src/Queries/QueryRunner/QueryRunner.ts
+++ b/src/Queries/QueryRunner/QueryRunner.ts
@@ -260,11 +260,12 @@ export class QueryRunner {
             ],
         });
 
-        if (params.relationship.properties) {
+        const { properties: props } = params.relationship;
+        if (props && JSON.stringify(props) !== JSON.stringify({})) {
             /** the relationship properties statement to be inserted into the final statement string */
             queryBuilder.set({
                 identifier: relationshipIdentifier,
-                properties: params.relationship.properties,
+                properties: props,
             });
         }
 


### PR DESCRIPTION
#### Problem

I had a problem when I used the `relateTo` function.

```shell
Neo4jError: Unexpected end of input: expected whitespace or SetItem (line 1, column 133 (offset: 132))
"MATCH (source:`Books`), (target:`Authors`) WHERE source.id = $id AND target.id = $id__aaaa CREATE (source)-[r:WriteBy]->(target) SET"
```

I dig and found the origin of the problem [here] (https://github.com/themetalfleece/neogma/blob/ba3f7e4783256f9e83f3ccb64042276a20081fc3/src/Queries/QueryRunner/QueryRunner.ts#L263), its create by the relationship property.

The problem is simple, you try it in your terminal : 

```
$ node
Welcome to Node.js v15.11.0.
Type ".help" for more information.
> {} == undefined
false
> {} === undefined
false
> {} === {}
false
> 
```

#### Solution

To improve the check of an empty object. I've add a condition that also check object content.

Signed-off-by: Tom Chauveau <tom.chauveau@epitech.eu>