### PR TITLE
Verify connectivity & NeogmaConnectivityError

### DIFF
--- a/documentation/md/docs/Getting-Started.md
+++ b/documentation/md/docs/Getting-Started.md
@@ -67,6 +67,15 @@ const neogma = new Neogma(
 
 This instance must be used when defining [Models](./Models/Overview).
 
+### Verify connectivity
+
+You can sun
+```js
+await neogma.verifyConnectivity();
+```
+
+If there is a connectivity error in either the neogma initialization, or with `verifyConnectivity`, a `NeogmaConnectivityError` error will be thrown.
+
 ## Utilities
 It also has the neo4j Driver and a [QueryRunner](./QueryRunner/Overview) instance. For more information about how to run your own queries and other non-model operations, refer to its documentation.
 

--- a/src/Errors/NeogmaConnectivityError.ts
+++ b/src/Errors/NeogmaConnectivityError.ts
@@ -1,0 +1,11 @@
+import { NeogmaError } from './NeogmaError';
+
+/** Error for when the connecting to neo4j is not possible */
+export class NeogmaConnectivityError extends NeogmaError {
+  constructor(data?: NeogmaConnectivityError['data']) {
+    super('Error while connecting to neo4j', data);
+    this.data = data || {};
+
+    Object.setPrototypeOf(this, NeogmaConnectivityError.prototype);
+  }
+}

--- a/src/ModelOps/ModelOps.spec.ts
+++ b/src/ModelOps/ModelOps.spec.ts
@@ -20,6 +20,9 @@ beforeAll(async () => {
     username: process.env.NEO4J_USERNAME ?? '',
     password: process.env.NEO4J_PASSWORD ?? '',
   });
+
+  await neogma.verifyConnectivity();
+
   QueryBuilder.queryRunner = neogma.queryRunner;
 });
 

--- a/src/Neogma.ts
+++ b/src/Neogma.ts
@@ -3,6 +3,7 @@ import { Config, Driver, Session, Transaction } from 'neo4j-driver';
 import { NeogmaModel } from './ModelOps';
 import { QueryRunner, Runnable } from './Queries/QueryRunner';
 import { getRunnable, getSession, getTransaction } from './Sessions/Sessions';
+import { NeogmaConnectivityError } from './Errors/NeogmaConnectivityError';
 const neo4j = neo4j_driver;
 
 interface ConnectParamsI {
@@ -37,9 +38,7 @@ export class Neogma {
         options,
       );
     } catch (err) {
-      console.error(`Error while connecting to the neo4j database`);
-      console.error(err);
-      process.exit(-1);
+      throw new NeogmaConnectivityError(err);
     }
 
     this.queryRunner = new QueryRunner({
@@ -47,6 +46,14 @@ export class Neogma {
       logger: options?.logger,
     });
   }
+
+  public verifyConnectivity = async (): Promise<void> => {
+    try {
+      await this.driver.verifyConnectivity();
+    } catch (err) {
+      throw new NeogmaConnectivityError(err);
+    }
+  };
 
   public getSession = <T>(
     runInSession: Session | null,


### PR DESCRIPTION
Closes #60

- Add `NeogmaConnectivityError`.
- Add `verifyConnectivity` method to `Neogma` which throws `NeogmaConnectivityError`.
- Change `Neogma` constructor to throw `NeogmaConnectivityError` if the driver init fails.