### PR TITLE
Database and Session params

### DIFF
--- a/documentation/md/docs/Getting-Started.md
+++ b/documentation/md/docs/Getting-Started.md
@@ -53,6 +53,8 @@ const neogma = new Neogma(
         url: 'bolt://localhost:7687',
         username: 'neo4j',
         password: 'password',
+        /* --> (optional) the database to be used by default for sessions */
+        database: 'myDb',
     },
     {
         /* --> (optional) logs every query that Neogma runs, using the given function */

--- a/documentation/md/docs/Sessions-and-Transactions.md
+++ b/documentation/md/docs/Sessions-and-Transactions.md
@@ -74,7 +74,11 @@ await getSession(
         await myFindUser(session);
     },
     /* --> a neo4j driver is needed */
-    driver
+    driver,
+    {
+        /* --> pass any other params, as you would for the driver's `session` method */
+        database: "myDb"
+    }
 );
 /* --> at this stage, the session will close */
 ```
@@ -146,7 +150,11 @@ await getTransaction(
         );
     },
     /* --> a neo4j driver is needed */
-    driver
+    driver,
+    {
+        /* --> pass any other params, as you would for the driver's `session` method */
+        database: "myDb"
+    }
 );
 /* --> at this stage, the transaction will be committed */
 ```
@@ -165,7 +173,11 @@ await getRunnable(
         await queryRunner.run('RETURN 1 = 1', {}, session);
     },
     /* --> a neo4j driver is needed */
-    driver
+    driver,
+    {
+        /* --> pass any other params, as you would for the driver's `session` method */
+        database: "myDb"
+    }
 );
 ```
 
@@ -187,7 +199,7 @@ await getRunnable(
             driver
         );
     },
-    driver
+    driver,
 );
 ```
 

--- a/src/Neogma.ts
+++ b/src/Neogma.ts
@@ -10,6 +10,7 @@ interface ConnectParamsI {
   url: string;
   username: string;
   password: string;
+  database?: string;
 }
 
 interface ConnectOptionsI extends Config {
@@ -22,6 +23,7 @@ export class Neogma {
   public readonly queryRunner: QueryRunner;
   /** a map between each Model's modelName and the Model itself */
   public modelsByName: Record<string, NeogmaModel<any, any, any, any>> = {};
+  public database?: string;
 
   /**
    *
@@ -37,6 +39,8 @@ export class Neogma {
         neo4j.auth.basic(username, password),
         options,
       );
+
+      this.database = params.database;
     } catch (err) {
       throw new NeogmaConnectivityError(err);
     }
@@ -58,21 +62,45 @@ export class Neogma {
   public getSession = <T>(
     runInSession: Session | null,
     callback: (s: Session) => Promise<T>,
+    /**
+     * Override the configuration of the session.
+     * By default, the "database" param used in the constructor is always passed.
+     */
+    sessionConfig?: neo4j_driver.SessionConfig,
   ): Promise<T> => {
-    return getSession<T>(runInSession, callback, this.driver);
+    return getSession<T>(runInSession, callback, this.driver, {
+      database: this.database,
+      ...sessionConfig,
+    });
   };
 
   public getTransaction = <T>(
     runInTransaction: Runnable | null,
     callback: (tx: Transaction) => Promise<T>,
+    /**
+     * Override the configuration of the session.
+     * By default, the "database" param used in the constructor is always passed.
+     */
+    sessionConfig?: neo4j_driver.SessionConfig,
   ): Promise<T> => {
-    return getTransaction<T>(runInTransaction, callback, this.driver);
+    return getTransaction<T>(runInTransaction, callback, this.driver, {
+      database: this.database,
+      ...sessionConfig,
+    });
   };
 
   public getRunnable = <T>(
     runInExisting: Runnable | null,
     callback: (tx: Runnable) => Promise<T>,
+    /**
+     * Override the configuration of the session.
+     * By default, the "database" param used in the constructor is always passed.
+     */
+    sessionConfig?: neo4j_driver.SessionConfig,
   ): Promise<T> => {
-    return getRunnable<T>(runInExisting, callback, this.driver);
+    return getRunnable<T>(runInExisting, callback, this.driver, {
+      database: this.database,
+      ...sessionConfig,
+    });
   };
 }

--- a/src/Sessions/Sessions.ts
+++ b/src/Sessions/Sessions.ts
@@ -1,4 +1,4 @@
-import { Driver, Session, Transaction } from 'neo4j-driver';
+import { Driver, Session, SessionConfig, Transaction } from 'neo4j-driver';
 import { Runnable } from '../Queries/QueryRunner';
 
 const isTransaction = (tx: any): tx is Transaction =>
@@ -10,12 +10,13 @@ export const getSession = async <T>(
   runInSession: Session | null,
   callback: (s: Session) => Promise<T>,
   driver: Driver,
+  sessionParams?: SessionConfig,
 ): Promise<T> => {
   if (runInSession) {
     return callback(runInSession);
   }
 
-  const session = driver.session();
+  const session = driver.session(sessionParams);
   try {
     const result = await callback(session);
     await session.close();
@@ -32,6 +33,7 @@ export const getTransaction = async <T>(
   runInExisting: Runnable | null,
   callback: (tx: Transaction) => Promise<T>,
   driver: Driver,
+  sessionParams?: SessionConfig,
 ): Promise<T> => {
   // if it's a transaction, return it with the callback
   if (isTransaction(runInExisting)) {
@@ -53,6 +55,7 @@ export const getTransaction = async <T>(
       }
     },
     driver,
+    sessionParams,
   );
 };
 
@@ -61,9 +64,10 @@ export const getRunnable = async <T>(
   runInExisting: Runnable | null | undefined,
   callback: (tx: Runnable) => Promise<T>,
   driver: Driver,
+  sessionParams?: SessionConfig,
 ): Promise<T> => {
   if (runInExisting) {
     return callback(runInExisting);
   }
-  return getSession(null, callback, driver);
+  return getSession(null, callback, driver, sessionParams);
 };


### PR DESCRIPTION
- Add `sessionParams` to all Session-related methods.
- Add `database` to the Neogma constructor.
- Add `sessionParams` to all Neogma Session-related method, while passing `database` as the default.