### PR TITLE
Add sessionParams to QueryBuilder and QueryRunner

### DIFF
--- a/documentation/md/docs/QueryBuilder/Overview.md
+++ b/documentation/md/docs/QueryBuilder/Overview.md
@@ -117,14 +117,6 @@ An existing session can be given
         .run(queryRunner, session);
 ```
 
-If no session is given, configuration for the session to be created can be given
-```js
-    /** let 'queryRunner' be a QueryRunner instance and 'session' be a Session/Transaction */
-    await new QueryBuilder()
-        .raw('match n return n')
-        .run(queryRunner, null, { database: 'myDb' });
-```
-
 In order to avoid having to provide the QueryRunner instance on every call, the static `queryRunner` can be set.
 This can be done as soon as the `Neogma` instance is created, and should be set only once.
 ```js

--- a/documentation/md/docs/QueryBuilder/Overview.md
+++ b/documentation/md/docs/QueryBuilder/Overview.md
@@ -115,7 +115,15 @@ An existing session can be given
     await new QueryBuilder()
         .raw('match n return n')
         .run(queryRunner, session);
-``` 
+```
+
+If no session is given, configuration for the session to be created can be given
+```js
+    /** let 'queryRunner' be a QueryRunner instance and 'session' be a Session/Transaction */
+    await new QueryBuilder()
+        .raw('match n return n')
+        .run(queryRunner, null, { database: 'myDb' });
+```
 
 In order to avoid having to provide the QueryRunner instance on every call, the static `queryRunner` can be set.
 This can be done as soon as the `Neogma` instance is created, and should be set only once.

--- a/documentation/md/docs/QueryRunner/Overview.md
+++ b/documentation/md/docs/QueryRunner/Overview.md
@@ -12,6 +12,10 @@ const queryRunner = new QueryRunner({
     driver: neogma.driver,
     /* --> (optional) logs every query that this QueryRunner instance runs, using the given function */
     logger: console.log
+    /* --> (optional) Session config to be used when creating a session to run any query. If a custom session is passed to any method, this param will be ignored. */
+    sessionParams: {
+        database: 'myDb'
+    },
 });
 ```
 

--- a/src/Neogma.ts
+++ b/src/Neogma.ts
@@ -48,6 +48,9 @@ export class Neogma {
     this.queryRunner = new QueryRunner({
       driver: this.driver,
       logger: options?.logger,
+      sessionParams: {
+        database: this.database,
+      },
     });
   }
 

--- a/src/Queries/QueryBuilder/QueryBuilder.ts
+++ b/src/Queries/QueryBuilder/QueryBuilder.ts
@@ -1,6 +1,6 @@
 import { getRunnable } from '../../Sessions';
 import { NeogmaConstraintError, NeogmaError } from '../../Errors';
-import { SessionConfig, int } from 'neo4j-driver';
+import { int } from 'neo4j-driver';
 import { QueryResult } from 'neo4j-driver';
 import { trimWhitespace } from '../../utils/string';
 import { BindParam } from '../BindParam';
@@ -797,8 +797,6 @@ export class QueryBuilder {
     queryRunnerOrRunnable?: QueryRunner | Runnable | null,
     /** an existing session to use. Set it only if the first param is a QueryRunner instance */
     existingSession?: Runnable | null,
-    /** these params will be used for the session if existingSession is null/undefined */
-    sessionParams?: SessionConfig,
   ): Promise<QueryResult> {
     const queryRunner =
       queryRunnerOrRunnable instanceof QueryRunner
@@ -825,7 +823,7 @@ export class QueryBuilder {
         );
       },
       queryRunner.getDriver(),
-      sessionParams,
+      queryRunner.sessionParams,
     );
   }
 

--- a/src/Queries/QueryBuilder/QueryBuilder.ts
+++ b/src/Queries/QueryBuilder/QueryBuilder.ts
@@ -1,6 +1,6 @@
 import { getRunnable } from '../../Sessions';
 import { NeogmaConstraintError, NeogmaError } from '../../Errors';
-import { int } from 'neo4j-driver';
+import { SessionConfig, int } from 'neo4j-driver';
 import { QueryResult } from 'neo4j-driver';
 import { trimWhitespace } from '../../utils/string';
 import { BindParam } from '../BindParam';
@@ -797,6 +797,8 @@ export class QueryBuilder {
     queryRunnerOrRunnable?: QueryRunner | Runnable | null,
     /** an existing session to use. Set it only if the first param is a QueryRunner instance */
     existingSession?: Runnable | null,
+    /** these params will be used for the session if existingSession is null/undefined */
+    sessionParams?: SessionConfig,
   ): Promise<QueryResult> {
     const queryRunner =
       queryRunnerOrRunnable instanceof QueryRunner
@@ -823,6 +825,7 @@ export class QueryBuilder {
         );
       },
       queryRunner.getDriver(),
+      sessionParams,
     );
   }
 

--- a/src/Queries/QueryRunner/QueryRunner.ts
+++ b/src/Queries/QueryRunner/QueryRunner.ts
@@ -69,7 +69,7 @@ export interface CreateRelationshipParamsI {
 
 export class QueryRunner {
   private driver: Driver;
-  private sessionParams?: SessionConfig;
+  public sessionParams?: SessionConfig;
   /** whether to log the statements and parameters with the given function */
   private logger:
     | null
@@ -167,7 +167,7 @@ export class QueryRunner {
       queryBuilder.return(identifier);
     }
 
-    return this.runQueryBuilder(queryBuilder, params.session);
+    return queryBuilder.run(this, params.session);
   };
 
   public delete = async (params: {
@@ -200,7 +200,7 @@ export class QueryRunner {
       detach,
     });
 
-    return this.runQueryBuilder(queryBuilder, params.session);
+    return queryBuilder.run(this, params.session);
   };
 
   public createRelationship = async (
@@ -265,19 +265,11 @@ export class QueryRunner {
       });
     }
 
-    return this.runQueryBuilder(queryBuilder, params.session);
+    return queryBuilder.run(this, params.session);
   };
 
   /** maps a session object to a uuid, for logging purposes */
   private sessionIdentifiers = new WeakMap<Runnable, string>([]);
-
-  /** wrapper of running a querybuilder, will passing the correct parameters */
-  private runQueryBuilder = (
-    queryBuilder: QueryBuilder,
-    session: Runnable | null | undefined,
-  ) => {
-    return queryBuilder.run(this, session, this.sessionParams);
-  };
 
   /** runs a statement */
   public run(


### PR DESCRIPTION
- Add `sessionParams` property to `QueryBuilder`.
- `QueryRunner` uses it when running queries or when calling `queryBuilder.run()`.
- `QueryBuilder` uses it when calling `getRunnable` in its `run` method.
- Pass the `sessionParams` of the Neogma instance to `QueryRunner`.