### PR TITLE
refactor: Allow multiple operators in Where class for each property

### DIFF
--- a/src/Queries/Where/Where.spec.ts
+++ b/src/Queries/Where/Where.spec.ts
@@ -88,6 +88,38 @@ describe('Where', () => {
 
       expect(where.getBindParam().get()).toEqual(expectedValues);
     });
+
+    it('Support more than one operator per property', () => {
+      const where = new Where({
+        identifier: {
+          property: {
+            [Op.gte]: '2021-01-01',
+            [Op.lte]: '2023-01-01',
+          },
+          primaryProperty: {
+            [Op.eq]: 'someId',
+          },
+        },
+      });
+      const whereString = where.getStatement('text');
+      expect(
+        whereString.includes(
+          'identifier.property >= $property AND identifier.property <= $property__aaaa',
+        ),
+      ).toBeTruthy();
+
+      expect(
+        whereString.includes('identifier.primaryProperty = $primaryProperty'),
+      ).toBeTruthy();
+
+      try {
+        where.getStatement('object');
+      } catch (error) {
+        expect(error.message).toEqual(
+          'The only operator which is supported for object mode is "eq"',
+        );
+      }
+    });
   });
 
   describe('addParams', () => {

--- a/src/Queries/Where/Where.ts
+++ b/src/Queries/Where/Where.ts
@@ -232,7 +232,7 @@ export class Where {
             operator: 'eq',
           });
         } else if (value !== null && value !== undefined) {
-          if (typeof value !== 'object') return this;
+          if (typeof value !== 'object') continue;
           const symbols = Object.getOwnPropertySymbols(value);
           for (const symbol of symbols) {
             const operator = symbol.description;

--- a/src/Queries/Where/Where.ts
+++ b/src/Queries/Where/Where.ts
@@ -231,13 +231,11 @@ export class Where {
             value,
             operator: 'eq',
           });
-        } else if (value !== null && value !== undefined) {
-          if (typeof value !== 'object') continue;
+        } else if (value !== null && typeof value === 'object') {
           const symbols = Object.getOwnPropertySymbols(value);
           for (const symbol of symbols) {
-            const operator = symbol.description;
-            if (!operator || !operators.includes(operator)) continue;
-            if (isOperator[operator](value)) {
+            const operator = symbol.description ?? '';
+            if (operators.includes(operator) && isOperator[operator](value)) {
               this.addBindParamDataEntry({
                 identifier: nodeIdentifier,
                 property,

--- a/src/Queries/Where/Where.ts
+++ b/src/Queries/Where/Where.ts
@@ -59,7 +59,7 @@ type WhereTypes = {
   };
 };
 
-const operators = [
+const operators: string[] = [
   'eq',
   'in',
   '_in',
@@ -232,7 +232,11 @@ export class Where {
             operator: 'eq',
           });
         } else if (value !== null && value !== undefined) {
-          for (const operator of operators) {
+          if (typeof value !== 'object') return this;
+          const symbols = Object.getOwnPropertySymbols(value);
+          for (const symbol of symbols) {
+            const operator = symbol.description;
+            if (!operator || !operators.includes(operator)) continue;
             if (isOperator[operator](value)) {
               this.addBindParamDataEntry({
                 identifier: nodeIdentifier,
@@ -240,7 +244,6 @@ export class Where {
                 value: value[Op[operator]],
                 operator,
               });
-              break;
             }
           }
         }

--- a/src/Queries/Where/Where.ts
+++ b/src/Queries/Where/Where.ts
@@ -59,7 +59,7 @@ type WhereTypes = {
   };
 };
 
-const operators: string[] = [
+const operators = [
   'eq',
   'in',
   '_in',
@@ -233,9 +233,9 @@ export class Where {
           });
         } else if (value !== null && typeof value === 'object') {
           const symbols = Object.getOwnPropertySymbols(value);
-          for (const symbol of symbols) {
-            const operator = symbol.description ?? '';
-            if (operators.includes(operator) && isOperator[operator](value)) {
+          for (const { description } of symbols) {
+            const operator = description as (typeof operators)[number];
+            if (operator && isOperator[operator]?.(value)) {
               this.addBindParamDataEntry({
                 identifier: nodeIdentifier,
                 property,


### PR DESCRIPTION
# Description

This PR addresses an issue where the Where class in Neogma was not allowing multiple operators per property. This change fixes that omission, enabling the use of multiple operators for each property in the Where class.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To verify these changes, I performed the following tests:

- [X] Test for adding two operators to a property

**Test Configuration**:

- SDK: Jest
- Software version: 26
- Toolchain: super-test

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
